### PR TITLE
[matrix] Fixes for addon.xml and language files

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -25,8 +25,6 @@
 - remove YouTube option from menu (the option hasn't worked for quite some time)
     </news>
     <platform>all</platform>
-
-Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras</description>
     <license>GPL-3.0-ONLY</license>
     <forum>https://forum.kodi.tv/showthread.php?tid=312338</forum>
     <source>https://github.com/tamland/kodi-addon-extras</source>
@@ -36,8 +34,6 @@ Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/vie
       <fanart>fanart.jpg</fanart>
     </assets>
   </extension>
-
-Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras</description>
-    <summary lang="en_GB">View extras and special features</summary>
-    <description lang="en_GB">Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras</description>
+  <summary lang="en_GB">View extras and special features</summary>
+  <description lang="en_GB">Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the &quot;Extras&quot; sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras</description>
 </addon>

--- a/addon.xml
+++ b/addon.xml
@@ -20,10 +20,7 @@
     <provides>video</provides>
   </extension>
   <extension point="kodi.addon.metadata">
-    <news>1.4.2
-- updated language files
-- remove YouTube option from menu (the option hasn't worked for quite some time)
-    </news>
+    <news>1.4.2[CR]- updated language files[CR]- remove YouTube option from menu (the option hasn't worked for quite some time)</news>
     <platform>all</platform>
     <license>GPL-3.0-ONLY</license>
     <forum>https://forum.kodi.tv/showthread.php?tid=312338</forum>

--- a/resources/language/resource.language.af_za/strings.po
+++ b/resources/language/resource.language.af_za/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.am_et/strings.po
+++ b/resources/language/resource.language.am_et/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ast_es/strings.po
+++ b/resources/language/resource.language.ast_es/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.az_az/strings.po
+++ b/resources/language/resource.language.az_az/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.be_by/strings.po
+++ b/resources/language/resource.language.be_by/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.bs_ba/strings.po
+++ b/resources/language/resource.language.bs_ba/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ca_es/strings.po
+++ b/resources/language/resource.language.ca_es/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.cy_gb/strings.po
+++ b/resources/language/resource.language.cy_gb/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.da_dk/strings.po
+++ b/resources/language/resource.language.da_dk/strings.po
@@ -18,12 +18,9 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
 
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 msgctxt "#30000"
 msgid "Extras"
 msgstr "Ekstra"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.en_au/strings.po
+++ b/resources/language/resource.language.en_au/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -4,6 +4,14 @@
 msgid ""
 msgstr ""
 
+msgctxt "Addon Summary"
+msgid "View extras and special features"
+msgstr ""
+
+msgctxt "Addon Description"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgstr ""
+
 msgctxt "#30000"
 msgid "Extras"
 msgstr ""
@@ -14,12 +22,4 @@ msgstr ""
 
 msgctxt "#30002"
 msgid "To use this add-on go to the video library and open the context menu on a movie or TV show."
-msgctxt "Addon Summary"
-msgid "View extras and special features"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
-msgstr ""
-
 msgstr ""

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.eo/strings.po
+++ b/resources/language/resource.language.eo/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.es_ar/strings.po
+++ b/resources/language/resource.language.es_ar/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.es_mx/strings.po
+++ b/resources/language/resource.language.es_mx/strings.po
@@ -18,12 +18,9 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
 
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 msgctxt "#30000"
 msgid "Extras"
 msgstr "Extras"

--- a/resources/language/resource.language.et_ee/strings.po
+++ b/resources/language/resource.language.et_ee/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.fa_ir/strings.po
+++ b/resources/language/resource.language.fa_ir/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.fo_fo/strings.po
+++ b/resources/language/resource.language.fo_fo/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -18,12 +18,9 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
 
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 msgctxt "#30000"
 msgid "Extras"
 msgstr "תוספות"

--- a/resources/language/resource.language.hi_in/strings.po
+++ b/resources/language/resource.language.hi_in/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.hy_am/strings.po
+++ b/resources/language/resource.language.hy_am/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.id_id/strings.po
+++ b/resources/language/resource.language.id_id/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.is_is/strings.po
+++ b/resources/language/resource.language.is_is/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.mi/strings.po
+++ b/resources/language/resource.language.mi/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.mk_mk/strings.po
+++ b/resources/language/resource.language.mk_mk/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ml_in/strings.po
+++ b/resources/language/resource.language.ml_in/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.mn_mn/strings.po
+++ b/resources/language/resource.language.mn_mn/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ms_my/strings.po
+++ b/resources/language/resource.language.ms_my/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.mt_mt/strings.po
+++ b/resources/language/resource.language.mt_mt/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.my_mm/strings.po
+++ b/resources/language/resource.language.my_mm/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -18,12 +18,9 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
 
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 msgctxt "#30000"
 msgid "Extras"
 msgstr "Ekstramateriale"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -18,12 +18,9 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
 
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 msgctxt "#30000"
 msgid "Extras"
 msgstr "Extras"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -18,12 +18,9 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
 
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 msgctxt "#30000"
 msgid "Extras"
 msgstr "Доп. материалы"

--- a/resources/language/resource.language.scn/strings.po
+++ b/resources/language/resource.language.scn/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.si_lk/strings.po
+++ b/resources/language/resource.language.si_lk/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.sl_si/strings.po
+++ b/resources/language/resource.language.sl_si/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.sq_al/strings.po
+++ b/resources/language/resource.language.sq_al/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.sr_rs/strings.po
+++ b/resources/language/resource.language.sr_rs/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.szl/strings.po
+++ b/resources/language/resource.language.szl/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.ta_in/strings.po
+++ b/resources/language/resource.language.ta_in/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.te_in/strings.po
+++ b/resources/language/resource.language.te_in/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.tg_tj/strings.po
+++ b/resources/language/resource.language.tg_tj/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.th_th/strings.po
+++ b/resources/language/resource.language.th_th/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.uz_uz/strings.po
+++ b/resources/language/resource.language.uz_uz/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.vi_vn/strings.po
+++ b/resources/language/resource.language.vi_vn/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -18,12 +18,9 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
 
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 msgctxt "#30000"
 msgid "Extras"
 msgstr "附加"

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -17,12 +17,8 @@ msgid "View extras and special features"
 msgstr ""
 
 msgctxt "Addon Description"
-msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the Extras sub-folder for content (can be changed in settings).Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
+msgid "Provides an easy way to browse and view movie and TV show extras. Extras can be accessed from the context menu in the video library. By default, the add-on will look in the \"Extras\" sub-folder for content (can be changed in settings).[CR][CR]Tip: for how to avoid extras beings scraped to library, see http://kodi.wiki/view/Add-on:Extras"
 msgstr ""
-
-# XBMC Media Center language file
-# Addon Name: Extras
-# Addon id: context.item.extras
 
 msgctxt "#30000"
 msgid "Extras"


### PR DESCRIPTION
This PR contains fixes for addon.xml and language files.

Using `"` in a description, summary or disclaimer in addon.xml is not allowed and will create issues.
Please use `%quot;` instead.

In language files `\"` must be used instead of `"`.

The action will convert from `&quot;` to `\"` and back between language files and addon.xml
  
  
Also, please ude `[CR]` instead of regular return.
  
  
Please look carefully through this PR.
I tried to recreate all content from before the issues.

Thanks!

Cheers
Gade